### PR TITLE
日付選択入力方式の追加

### DIFF
--- a/backend/tests/test_validator.py
+++ b/backend/tests/test_validator.py
@@ -18,6 +18,13 @@ def test_validate_number() -> None:
         Validator.validate_partial(items, {"age": "thirty"})
 
 
+def test_validate_date() -> None:
+    items = [QuestionnaireItem(id="visit", label="受診日", type="date", required=False)]
+    Validator.validate_partial(items, {"visit": "2024-01-30"})
+    with pytest.raises(HTTPException):
+        Validator.validate_partial(items, {"visit": "2024-02-30"})
+
+
 def test_missing_required() -> None:
     items = [QuestionnaireItem(id="cc", label="主訴", type="string", required=True)]
     missing = Validator.missing_required(items, {})

--- a/docs/PlannedDesign.md
+++ b/docs/PlannedDesign.md
@@ -222,7 +222,7 @@
 ---
 
 ## 12. 管理者機能の詳細仕様
-- **テンプレ項目の型**：`text`, `multi`, `yesno`（3種に簡素化）。
+- **テンプレ項目の型**：`text`, `multi`, `yesno`, `date`（4種。`date`は年・月・日をプルダウン選択）。
 - **条件表示**：`when: { itemId, operator, value }[]`（ANDで評価）
 - **公開/下書き**：公開のみ患者側に配信。編集はドラフトで行い、公開で差替。
 - **プレビュー**：右パネルに患者画面の疑似レンダリング。種別切替可。
@@ -279,7 +279,7 @@
 interface QuestionItem {
   id: string;
   label: string;
-  inputType: 'text' | 'multi' | 'yesno';
+  inputType: 'text' | 'multi' | 'yesno' | 'date';
   required?: boolean;
   description?: string;
   options?: { value: string; label: string }[]; // single/multi
@@ -290,7 +290,7 @@ interface QuestionItem {
 interface LlmQuestion {
   id: string;            // new-xxx など
   text: string;          // 質問文
-  expectedInputType: 'text' | 'multi' | 'yesno';
+  expectedInputType: 'text' | 'multi' | 'yesno' | 'date';
   options?: { value: string; label: string }[];
   priority?: number;     // 低いほど高優先
 }

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -58,7 +58,7 @@
   - [x] **患者**：Entry（氏名/生年月日＋受診種別）→ Questionnaire → Questions → Review → Done
     - [x] Entry で氏名・生年月日を入力
     - [x] Entry で「当院の受診は初めてですか？」を選択（「初めて」= initial / 「受診したことがある」= followup）しセッション作成
-    - [x] Questionnaire で text/multi/yesno に応じた入力フォームを表示
+    - [x] Questionnaire で text/multi/yesno/date に応じた入力フォームを表示
     - [x] Questions で追加質問を順次表示
     - [x] Review で回答一覧を表示しインライン編集後確定へ進む
   - [x] Done で要約を表示

--- a/docs/plannedSystem.md
+++ b/docs/plannedSystem.md
@@ -48,7 +48,7 @@
 - **監視**：/healthz（死活）・/readyz（依存疎通）・/metrics（OpenMetrics）。
 
 ### 2. マイルストーン（MS）
-- **MS1 テンプレ整備**：問診テンプレート CRUD と `get_template_for_visit_type` の動作確認（項目型は text/multi/yesno のみ）。
+- **MS1 テンプレ整備**：問診テンプレート CRUD と `get_template_for_visit_type` の動作確認（項目型は text/multi/yesno/date）。
   - 補足：システム既定テンプレートのラベルは「質問文形式」（例：主訴は何ですか？、発症時期はいつからですか？）で初期化する。
 - **MS2 セッション基盤**：`SessionFSM` 初期化（`remaining_items`/`completion_status`/`attempt_counts`）、`StructuredContextManager` による永続更新。
 - **MS3 追加質問ループ**：`step("answer")` で回答受領→`LLMGateway.generate_question` による未質問項目の質問生成→`Validator.is_complete` 判定→不足時に `LLMGateway.decide_or_ask` で追質問（項目ごと最大3回・セッションあたりの上限N）。

--- a/frontend/src/components/DateSelect.tsx
+++ b/frontend/src/components/DateSelect.tsx
@@ -1,0 +1,45 @@
+import { HStack, Select } from '@chakra-ui/react';
+import { useMemo } from 'react';
+
+/** 年月日をプルダウンで選択する日付入力コンポーネント */
+export default function DateSelect({ value, onChange }: { value?: string; onChange: (val: string) => void; }) {
+  const [year, month, day] = (value || '').split('-');
+  const years = useMemo(() => {
+    const current = new Date().getFullYear();
+    return Array.from({ length: current - 1899 }, (_, i) => String(current - i));
+  }, []);
+  const months = Array.from({ length: 12 }, (_, i) => String(i + 1).padStart(2, '0'));
+  const daysInMonth = useMemo(() => {
+    if (!year || !month) return 31;
+    return new Date(Number(year), Number(month), 0).getDate();
+  }, [year, month]);
+  const days = Array.from({ length: daysInMonth }, (_, i) => String(i + 1).padStart(2, '0'));
+
+  const update = (y: string, m: string, d: string) => {
+    if (y && m && d) {
+      onChange(`${y}-${m}-${d}`);
+    } else {
+      onChange('');
+    }
+  };
+
+  return (
+    <HStack>
+      <Select placeholder="年" value={year || ''} onChange={(e) => update(e.target.value, month, day)}>
+        {years.map((y) => (
+          <option key={y} value={y}>{y}</option>
+        ))}
+      </Select>
+      <Select placeholder="月" value={month || ''} onChange={(e) => update(year, e.target.value, day)}>
+        {months.map((m) => (
+          <option key={m} value={m}>{m}</option>
+        ))}
+      </Select>
+      <Select placeholder="日" value={day || ''} onChange={(e) => update(year, month, e.target.value)}>
+        {days.map((d) => (
+          <option key={d} value={d}>{d}</option>
+        ))}
+      </Select>
+    </HStack>
+  );
+}

--- a/frontend/src/pages/AdminTemplates.tsx
+++ b/frontend/src/pages/AdminTemplates.tsx
@@ -37,6 +37,7 @@ import {
   ModalBody,
 } from '@chakra-ui/react';
 import { DeleteIcon, CheckCircleIcon, WarningIcon } from '@chakra-ui/icons';
+import DateSelect from '../components/DateSelect';
 
 interface Item {
   id: string;
@@ -487,6 +488,7 @@ export default function AdminTemplates() {
                           <option value="string">テキスト</option>
                           <option value="multi">複数選択</option>
                           <option value="yesno">はい/いいえ</option>
+                          <option value="date">日付</option>
                         </Select>
                       </FormControl>
                       <IconButton
@@ -583,6 +585,7 @@ export default function AdminTemplates() {
                     <option value="string">テキスト</option>
                     <option value="multi">複数選択</option>
                     <option value="yesno">はい/いいえ</option>
+                    <option value="date">日付</option>
                   </Select>
                 </FormControl>
                 {['multi'].includes(newItem.type) && (
@@ -707,6 +710,11 @@ export default function AdminTemplates() {
                             ))}
                           </VStack>
                         </CheckboxGroup>
+                      ) : item.type === 'date' ? (
+                        <DateSelect
+                          value={previewAnswers[item.id] || ''}
+                          onChange={(val) => setPreviewAnswers({ ...previewAnswers, [item.id]: val })}
+                        />
                       ) : (
                         <Input
                           onChange={(e) => setPreviewAnswers({ ...previewAnswers, [item.id]: e.target.value })}

--- a/frontend/src/pages/QuestionnaireForm.tsx
+++ b/frontend/src/pages/QuestionnaireForm.tsx
@@ -17,6 +17,7 @@ import { useNavigate } from 'react-router-dom';
 import { postWithRetry } from '../retryQueue';
 import ErrorSummary from '../components/ErrorSummary';
 import { track } from '../metrics';
+import DateSelect from '../components/DateSelect';
 
 interface Item {
   id: string;
@@ -190,6 +191,11 @@ export default function QuestionnaireForm() {
                   ))}
                 </VStack>
               </CheckboxGroup>
+            ) : item.type === 'date' ? (
+              <DateSelect
+                value={answers[item.id] || ''}
+                onChange={(val) => setAnswers({ ...answers, [item.id]: val })}
+              />
             ) : (
               <Input
                 id={`item-${item.id}`}

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { postWithRetry } from '../retryQueue';
 import { track } from '../metrics';
+import DateSelect from '../components/DateSelect';
 
 interface Item {
   id: string;
@@ -102,10 +103,9 @@ export default function Review() {
               onChange={(e) => setAnswers({ ...answers, [item.id]: e.target.value })}
             />
           ) : item.type === 'date' ? (
-            <Input
-              type="date"
+            <DateSelect
               value={answers[item.id] || ''}
-              onChange={(e) => setAnswers({ ...answers, [item.id]: e.target.value })}
+              onChange={(val) => setAnswers({ ...answers, [item.id]: val })}
             />
           ) : item.type === 'single' && item.options ? (
             <RadioGroup


### PR DESCRIPTION
## 概要
- 年・月・日をプルダウンで選択する`date`入力方式を実装
- 管理画面/患者画面/確認画面を`date`入力に対応
- 仕様書・実装状況に`date`型を追記

## テスト
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8f3c36e78832f8a53aefc6d6a8852