### PR TITLE
fix: 管理画面ヘッダーを固定文言に変更

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -333,12 +333,12 @@
   - 変更: `frontend/index.html` の `<title>`。
 
 ## 33. システム表示名の設定機能（2025-08-23）
-- [x] 管理画面から「システム表示名」を編集可能にし、ヘッダーに反映。
+- [x] 管理画面から「システム表示名」を編集可能にし、患者画面のヘッダーに反映（管理画面のヘッダーは固定文言「管理画面」とし設定の影響を受けない）。
   - 変更（バックエンド）: `backend/app/db.py` に `app_settings` テーブルと `save_app_settings` / `load_app_settings` を追加。
   - 変更（バックエンド）: `backend/app/main.py` に `GET/PUT /system/display-name` を追加（既定値は「Monshinクリニック」）。
   - 変更（フロント）: `frontend/src/pages/AdminSystemName.tsx` を追加（入力+保存UI）。
   - 変更（フロント）: `frontend/src/components/AdminLayout.tsx` のメニューに「システム表示名」を追加。
-  - 変更（フロント）: `frontend/src/App.tsx` で表示名を取得・購読し、ヘッダーに表示。設定保存時はカスタムイベントで即時反映。
+  - 変更（フロント）: `frontend/src/App.tsx` で表示名を取得・購読し、患者画面のヘッダーに表示。設定保存時はカスタムイベントで即時反映。
   - 変更（開発プロキシ）: `frontend/vite.config.ts` に `/system` を追加し、開発時のAPI疎通404を解消。
 
 ## 34. フッターに小さく「問診メイト」を表示（2025-08-23）

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -112,7 +112,7 @@ export default function App() {
     >
       {!isChatPage && (
         <Flex as="header" mb={4} align="center">
-          <Heading size="lg">{displayName}</Heading>
+          <Heading size="lg">{isAdminPage ? '管理画面' : displayName}</Heading>
           <Spacer />
           {isAdminPage ? (
             <Button


### PR DESCRIPTION
## Summary
- 管理画面ヘッダーを固定文言「管理画面」に変更し、設定のシステム表示名は患者画面のみで利用
- システム表示名仕様を更新

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a991778600832f827248dbdaeb480f