### PR TITLE
reset_admin_password.pyでパスワード・TOTP更新日時カラムを補完

### DIFF
--- a/backend/tools/reset_admin_password.py
+++ b/backend/tools/reset_admin_password.py
@@ -7,6 +7,7 @@
 - 新しいパスワードをハッシュ化して `users.username='admin'` に設定
 - is_initial_password=1, is_totp_enabled=0, totp_mode='off', totp_secret=NULL に更新（TOTP無効化）
 - admin ユーザーが存在しない場合は作成
+- 既存DBに不足するカラム（`is_initial_password`, `totp_mode`, `password_updated_at`, `totp_changed_at`）を自動追加（存在時は無視）
 
 注意:
 - 実行前に必ず DB バックアップを取得してください（backend/app/app.sqlite3 をコピー）。
@@ -73,6 +74,18 @@ def ensure_users_table(conn: sqlite3.Connection) -> None:
     try:
         conn.execute(
             "ALTER TABLE users ADD COLUMN totp_mode TEXT NOT NULL DEFAULT 'off'"
+        )
+    except Exception:
+        pass
+    try:
+        conn.execute(
+            "ALTER TABLE users ADD COLUMN password_updated_at TEXT"
+        )
+    except Exception:
+        pass
+    try:
+        conn.execute(
+            "ALTER TABLE users ADD COLUMN totp_changed_at TEXT"
         )
     except Exception:
         pass

--- a/docs/admin_system_setup.md
+++ b/docs/admin_system_setup.md
@@ -85,7 +85,7 @@ python backend/tools/reset_admin_password.py --password "NewStrongPass123"
 
 ### 注意事項
 
-- 既存DBに `totp_mode` カラムが存在しない場合でも、スクリプトが自動で追加します（既存環境に影響が出ないよう例外は握り潰します）。
+ - 既存DBに `totp_mode`, `password_updated_at`, `totp_changed_at` カラムが存在しない場合でも、スクリプトが自動で追加します（既存環境に影響が出ないよう例外は握り潰します）。
 - 本スクリプトはローカル実行を前提としています。運用環境での実行は手順、権限、監査ログの扱いに注意してください。
 
 ## 8. 付録：監査ログの確認方法（開発向け）

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -422,3 +422,7 @@
   - 変更: `frontend/src/pages/AdminPasswordReset.tsx`
   - 変更: `frontend/src/pages/AdminLogin.tsx`
   - ドキュメント更新: `docs/admin_system_setup.md`, `frontend/public/docs/admin_system_setup.md`
+
+## 48. オフラインリセットスクリプトでのユーザーテーブル列保証（2025-11-06）
+- [x] `backend/tools/reset_admin_password.py` の `ensure_users_table` が `password_updated_at` と `totp_changed_at` カラムを既存DBに追加するよう修正。
+- [x] ドキュメント更新: `docs/admin_system_setup.md`


### PR DESCRIPTION
## 概要
- reset_admin_password.pyのユーザーテーブル整備で`password_updated_at`と`totp_changed_at`を自動追加
- ドキュメントに対応内容を追記し、実装記録を更新

## テスト
- `sqlite3 /tmp/old.sqlite3 "PRAGMA table_info(users);"`
- `sqlite3 /tmp/old.sqlite3 "SELECT username, is_initial_password, totp_mode, password_updated_at, totp_changed_at FROM users;"`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aade83d158832fbd00df404f08778d