### PR TITLE
fix: 追質問判定時のエラーハンドリング改善

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -468,3 +468,7 @@
 - [x] サマリー作成モードが無効な場合は `POST /sessions/{id}/finalize` が空文字の要約を返すよう修正。
 - [x] サマリー作成モード有効時の要約生成を確認するテストを追加。
 - [x] ドキュメント更新: `docs/session_api.md`。
+
+## 56. 追加質問判定時のフェッチエラー処理改善（2025-11-13）
+- [x] LLM 追質問の要否判定および質問取得の際、HTTP エラーやネットワーク例外が発生した場合にレビュー画面へフォールバックするようにした。
+- [x] 変更: `frontend/src/pages/LlmWait.tsx`, `frontend/src/pages/Questions.tsx`。

--- a/frontend/src/pages/LlmWait.tsx
+++ b/frontend/src/pages/LlmWait.tsx
@@ -15,13 +15,15 @@ export default function LlmWait() {
     const check = async () => {
       try {
         const res = await fetch(`/sessions/${sessionId}/llm-questions`, { method: 'POST' });
+        if (!res.ok) throw new Error('http error');
         const data = await res.json();
         if (data.questions && data.questions.length > 0) {
           navigate('/questions');
         } else {
           navigate('/review');
         }
-      } catch {
+      } catch (e) {
+        console.error('llm question check failed', e);
         // 失敗時は追質問をスキップ
         navigate('/review');
       }

--- a/frontend/src/pages/Questions.tsx
+++ b/frontend/src/pages/Questions.tsx
@@ -20,11 +20,18 @@ export default function Questions() {
 
   const fetchQuestion = async () => {
     if (!sessionId) return;
-    const res = await fetch(`/sessions/${sessionId}/llm-questions`, { method: 'POST' });
-    const data = await res.json();
-    if (data.questions && data.questions.length > 0) {
-      setCurrent({ id: data.questions[0].id, text: data.questions[0].text });
-    } else {
+    try {
+      const res = await fetch(`/sessions/${sessionId}/llm-questions`, { method: 'POST' });
+      if (!res.ok) throw new Error('http error');
+      const data = await res.json();
+      if (data.questions && data.questions.length > 0) {
+        setCurrent({ id: data.questions[0].id, text: data.questions[0].text });
+      } else {
+        sessionStorage.setItem('answers', JSON.stringify(answers));
+        navigate('/review');
+      }
+    } catch (e) {
+      console.error('fetchQuestion failed', e);
       sessionStorage.setItem('answers', JSON.stringify(answers));
       navigate('/review');
     }
@@ -55,6 +62,7 @@ export default function Questions() {
       setAnswer('');
       setCurrent(null);
       const res = await fetch(`/sessions/${sessionId}/llm-questions`, { method: 'POST' });
+      if (!res.ok) throw new Error('http error');
       const data = await res.json();
       if (data.questions && data.questions.length > 0) {
         setCurrent({ id: data.questions[0].id, text: data.questions[0].text });


### PR DESCRIPTION
## Summary
- LLM追質問の要否判定および追加質問取得でHTTP/通信エラーを検出してレビュー画面へフォールバック
- 実装手順書にフェッチエラー処理改善を追記

## Testing
- `cd backend && python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac43006ce4832fa7909003e5fc015b