### PR TITLE
問診セッション開始時の旧データ削除と自動入力抑止

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -519,3 +519,8 @@
 - [x] ボタン直下に「パスワードをリセットするには二段階認証の有効化が必要であり推奨する」旨のメッセージを表示。
 - [x] 二段階認証が有効になって初めて「QRコードを表示」ボタンや「パスワードをリセット」ボタンが表示されるよう条件分岐を整理。
 - [x] 変更（フロントエンド）: `frontend/src/pages/AdminSecurity.tsx`。
+
+## 65. セッション開始時の旧データ初期化と自動入力抑止（2025-11-20）
+- [x] Entry ページ表示時に旧セッション情報を `sessionStorage` から削除し、常に新しいセッションIDで問診を開始できるようにした。
+- [x] 患者向け入力フォームの `autoComplete` を `off` に設定し、ブラウザの自動入力によるデータ混同を防止。
+- 変更: `frontend/src/pages/Entry.tsx`, `frontend/src/pages/QuestionnaireForm.tsx`, `frontend/src/pages/Questions.tsx`, `frontend/src/components/DateSelect.tsx`。

--- a/frontend/src/components/DateSelect.tsx
+++ b/frontend/src/components/DateSelect.tsx
@@ -25,20 +25,20 @@ export default function DateSelect({ value, onChange }: { value?: string; onChan
 
   return (
     <HStack>
-      <Select placeholder="年" value={year || ''} onChange={(e) => update(e.target.value, month, day)}>
+      <Select placeholder="年" value={year || ''} onChange={(e) => update(e.target.value, month, day)} autoComplete="off">
         {years.map((y) => (
           <option key={y} value={y}>{y}</option>
         ))}
       </Select>
-      <Select placeholder="月" value={month || ''} onChange={(e) => update(year, e.target.value, day)}>
+      <Select placeholder="月" value={month || ''} onChange={(e) => update(year, e.target.value, day)} autoComplete="off">
         {months.map((m) => (
           <option key={m} value={m}>{m}</option>
         ))}
       </Select>
-      <Select placeholder="日" value={day || ''} onChange={(e) => update(year, month, e.target.value)}>
-        {days.map((d) => (
-          <option key={d} value={d}>{d}</option>
-        ))}
+      <Select placeholder="日" value={day || ''} onChange={(e) => update(year, month, e.target.value)} autoComplete="off">
+    {days.map((d) => (
+      <option key={d} value={d}>{d}</option>
+    ))}
       </Select>
     </HStack>
   );

--- a/frontend/src/pages/Entry.tsx
+++ b/frontend/src/pages/Entry.tsx
@@ -35,6 +35,21 @@ export default function Entry() {
   const [attempted, setAttempted] = useState(false);
   const navigate = useNavigate();
 
+  // 新規セッション開始時に前回のデータをクリア
+  useEffect(() => {
+    [
+      'session_id',
+      'answers',
+      'questionnaire_items',
+      'summary',
+      'visit_type',
+      'llm_error',
+      'patient_name',
+      'dob',
+      'gender',
+    ].forEach((k) => sessionStorage.removeItem(k));
+  }, []);
+
   const handleNext = async () => {
     setAttempted(true);
     const errs: string[] = [];
@@ -103,6 +118,7 @@ export default function Entry() {
   }, []);
 
   return (
+    <form autoComplete="off" onSubmit={(e) => e.preventDefault()}>
     <VStack spacing={4} align="stretch">
       <ErrorSummary
         errors={[
@@ -117,7 +133,7 @@ export default function Entry() {
       />
       <FormControl isRequired isInvalid={attempted && !name}>
         <FormLabel htmlFor="patient_name">氏名</FormLabel>
-        <Input id="patient_name" placeholder="問診　太郎" autoFocus value={name} onChange={(e) => setName(e.target.value)} />
+        <Input id="patient_name" placeholder="問診　太郎" autoFocus value={name} onChange={(e) => setName(e.target.value)} autoComplete="off" />
         <FormErrorMessage>氏名を入力してください</FormErrorMessage>
       </FormControl>
       <FormControl isRequired isInvalid={attempted && !gender}>
@@ -139,20 +155,20 @@ export default function Entry() {
         <FormLabel>生年月日</FormLabel>
         <HStack>
           <Select id="dob-year" placeholder="年" value={dobYear}
-                  onChange={(e) => setDobYear(e.target.value ? Number(e.target.value) : '')}>
+                  onChange={(e) => setDobYear(e.target.value ? Number(e.target.value) : '')} autoComplete="off">
             {years.map((y) => (
               <option key={y} value={y}>{y}</option>
             ))}
           </Select>
           <Select id="dob-month" placeholder="月" value={dobMonth}
-                  onChange={(e) => setDobMonth(e.target.value ? Number(e.target.value) : '')}>
+                  onChange={(e) => setDobMonth(e.target.value ? Number(e.target.value) : '')} autoComplete="off">
             {months.map((m) => (
               <option key={m} value={m}>{m}</option>
             ))}
           </Select>
           <Select id="dob-day" placeholder="日" value={dobDay}
                   onChange={(e) => setDobDay(e.target.value ? Number(e.target.value) : '')}
-                  isDisabled={!dobYear || !dobMonth}>
+                  isDisabled={!dobYear || !dobMonth} autoComplete="off">
             {days.map((d) => (
               <option key={d} value={d}>{d}</option>
             ))}
@@ -181,5 +197,6 @@ export default function Entry() {
         </Button>
       </Flex>
     </VStack>
+    </form>
   );
 }

--- a/frontend/src/pages/QuestionnaireForm.tsx
+++ b/frontend/src/pages/QuestionnaireForm.tsx
@@ -166,6 +166,7 @@ export default function QuestionnaireForm() {
   }, [attempted, visibleItems, answers]);
 
   return (
+    <form autoComplete="off" onSubmit={(e) => e.preventDefault()}>
     <VStack spacing={6} align="stretch">
       <ErrorSummary errors={errorsForSummary} />
       {visibleItems.map((item) => (
@@ -245,6 +246,7 @@ export default function QuestionnaireForm() {
                       setFreeTexts({ ...freeTexts, [item.id]: val });
                       setAnswers({ ...answers, [item.id]: updated });
                     }}
+                    autoComplete="off"
                   />
                 )}
               </>
@@ -259,6 +261,7 @@ export default function QuestionnaireForm() {
                 aria-describedby={helperTexts[item.id] ? `help-item-${item.id}` : undefined}
                 value={answers[item.id] || ''}
                 onChange={(e) => setAnswers({ ...answers, [item.id]: e.target.value })}
+                autoComplete="off"
               />
             )}
             <FormErrorMessage>{item.label}を入力してください</FormErrorMessage>
@@ -269,5 +272,6 @@ export default function QuestionnaireForm() {
         次へ
       </Button>
     </VStack>
+    </form>
   );
 }

--- a/frontend/src/pages/Questions.tsx
+++ b/frontend/src/pages/Questions.tsx
@@ -102,16 +102,18 @@ export default function Questions() {
   };
 
   return (
+    <form autoComplete="off" onSubmit={(e) => e.preventDefault()}>
     <VStack spacing={4} align="stretch">
       {current && (
         <>
           <Box>{current.text}</Box>
-          <Input value={answer} onChange={(e) => setAnswer(e.target.value)} />
+          <Input value={answer} onChange={(e) => setAnswer(e.target.value)} autoComplete="off" />
           <Button onClick={submit} colorScheme="primary">
             送信
           </Button>
         </>
       )}
     </VStack>
+    </form>
   );
 }


### PR DESCRIPTION
## 概要
- Entry表示時に前回セッション情報をsessionStorageから削除
- 患者向けフォームでautoCompleteを無効化しブラウザの自動入力を抑止

## テスト
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1c0c5660832fbd01323020f7a3b6