### PR TITLE
複数選択肢の自由記述をチェックボックスで有効化

### DIFF
--- a/docs/PlannedDesign.md
+++ b/docs/PlannedDesign.md
@@ -272,7 +272,7 @@ interface QuestionItem {
   required?: boolean;
   description?: string;
   options?: { value: string; label: string }[]; // single/multi
-  allowFreeText?: boolean; // multi のときに自由記述欄を表示
+  allowFreeText?: boolean; // multi のときに自由記述欄をチェックボックスで有効化
   when?: { itemId: string; operator: 'eq' | 'ne' | 'in' | 'nin'; value: any }[];
 }
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -581,3 +581,8 @@
 - [x] `LlmWait` で取得した追加質問を `pending_llm_questions` として保存し、`Questions` ページで再利用するようにした。
 - [x] 質問を消費した際は `pending_llm_questions` を更新し、空になった場合のみ `/llm-questions` を再呼び出すよう変更。
 - [x] ドキュメント更新: `docs/session_api.md`。
+
+## 73. 複数選択項目の自由記述チェックボックス追加（2025-12-06）
+- [x] 複数選択肢で自由入力を行う際、専用チェックボックスを新設し、チェック時のみテキスト入力欄が有効化されるよう変更。
+- [x] 変更（フロントエンド）: `frontend/src/pages/QuestionnaireForm.tsx`
+- [x] ドキュメント更新: `docs/PlannedDesign.md`


### PR DESCRIPTION
## 概要
- 複数選択項目で自由記述を行う際、専用チェックボックスを設け、チェック時のみテキスト欄を有効化
- 仕様書と実装記録を更新

## テスト
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0eded43c832f929e5e1e73a976ba