### PR TITLE
デフォルトテンプレートの性別関連項目を整理

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,7 +113,6 @@ def on_startup() -> None:
     # 既定テンプレート（initial/followup）を投入（存在すれば上書き）
     initial_items = [
         # 氏名・生年月日はセッション作成時に別途入力するためテンプレートから除外
-        {"id": "sex", "label": "性別を選んでください。", "type": "single", "options": ["男性", "女性", "その他"], "required": True},
         {"id": "postal_code", "label": "郵便番号を記入してください。", "type": "string", "required": True},
         {"id": "address", "label": "住所を記入してください。", "type": "string", "required": True},
         {"id": "phone", "label": "電話番号を記入してください。", "type": "string", "required": True},
@@ -265,6 +264,7 @@ def on_startup() -> None:
             "label": "タバコは吸いますか？",
             "type": "single",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
+            "allow_freetext": True,
             "required": False,
         },
         {
@@ -272,10 +272,11 @@ def on_startup() -> None:
             "label": "お酒はのみますか？",
             "type": "single",
             "options": ["のまない", "ときどき", "よく飲む"],
+            "allow_freetext": True,
             "required": False,
         },
-        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False},
-        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False},
+        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False, "gender": "female"},
+        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False, "gender": "female"},
     ]
     followup_items = [
         {
@@ -599,7 +600,6 @@ def reset_default_template() -> dict:
     # on_startup と同じロジックで初期テンプレートを上書き
     initial_items = [
         # 氏名・生年月日はセッション作成時に別途入力するためテンプレートから除外
-        {"id": "sex", "label": "性別を選んでください。", "type": "single", "options": ["男性", "女性", "その他"], "required": True},
         {"id": "postal_code", "label": "郵便番号を記入してください。", "type": "string", "required": True},
         {"id": "address", "label": "住所を記入してください。", "type": "string", "required": True},
         {"id": "phone", "label": "電話番号を記入してください。", "type": "string", "required": True},
@@ -751,6 +751,7 @@ def reset_default_template() -> dict:
             "label": "タバコは吸いますか？",
             "type": "single",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
+            "allow_freetext": True,
             "required": False,
         },
         {
@@ -758,10 +759,11 @@ def reset_default_template() -> dict:
             "label": "お酒はのみますか？",
             "type": "single",
             "options": ["のまない", "ときどき", "よく飲む"],
+            "allow_freetext": True,
             "required": False,
         },
-        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False},
-        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False},
+        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False, "gender": "female"},
+        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False, "gender": "female"},
     ]
     followup_items = [
         {

--- a/backend/build/lib/app/main.py
+++ b/backend/build/lib/app/main.py
@@ -108,7 +108,6 @@ def on_startup() -> None:
     # 既定テンプレート（initial/followup）を投入（存在すれば上書き）
     initial_items = [
         # 氏名・生年月日はセッション作成時に別途入力するためテンプレートから除外
-        {"id": "sex", "label": "性別を選んでください。", "type": "single", "options": ["男性", "女性", "その他"], "required": True},
         {"id": "postal_code", "label": "郵便番号を記入してください。", "type": "string", "required": True},
         {"id": "address", "label": "住所を記入してください。", "type": "string", "required": True},
         {"id": "phone", "label": "電話番号を記入してください。", "type": "string", "required": True},
@@ -260,6 +259,7 @@ def on_startup() -> None:
             "label": "タバコは吸いますか？",
             "type": "single",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
+            "allow_freetext": True,
             "required": False,
         },
         {
@@ -267,10 +267,11 @@ def on_startup() -> None:
             "label": "お酒はのみますか？",
             "type": "single",
             "options": ["のまない", "ときどき", "よく飲む"],
+            "allow_freetext": True,
             "required": False,
         },
-        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False},
-        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False},
+        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False, "gender": "female"},
+        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False, "gender": "female"},
     ]
     followup_items = [
         {
@@ -581,7 +582,6 @@ def reset_default_template() -> dict:
     # on_startup と同じロジックで初期テンプレートを上書き
     initial_items = [
         # 氏名・生年月日はセッション作成時に別途入力するためテンプレートから除外
-        {"id": "sex", "label": "性別を選んでください。", "type": "single", "options": ["男性", "女性", "その他"], "required": True},
         {"id": "postal_code", "label": "郵便番号を記入してください。", "type": "string", "required": True},
         {"id": "address", "label": "住所を記入してください。", "type": "string", "required": True},
         {"id": "phone", "label": "電話番号を記入してください。", "type": "string", "required": True},
@@ -733,6 +733,7 @@ def reset_default_template() -> dict:
             "label": "タバコは吸いますか？",
             "type": "single",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
+            "allow_freetext": True,
             "required": False,
         },
         {
@@ -740,10 +741,11 @@ def reset_default_template() -> dict:
             "label": "お酒はのみますか？",
             "type": "single",
             "options": ["のまない", "ときどき", "よく飲む"],
+            "allow_freetext": True,
             "required": False,
         },
-        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False},
-        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False},
+        {"id": "pregnancy", "label": "妊娠中ですか？", "type": "yesno", "required": False, "gender": "female"},
+        {"id": "breastfeeding", "label": "授乳中ですか？", "type": "yesno", "required": False, "gender": "female"},
     ]
     followup_items = [
         {

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -29,7 +29,16 @@ def test_default_template_contains_items() -> None:
     assert res.status_code == 200
     ids = {item["id"] for item in res.json()["items"]}
     # 氏名(name)・生年月日(dob)はセッション作成時に別途入力するためテンプレートから除外
-    expected = {"sex", "postal_code", "address", "phone", "chief_complaint", "symptom_location", "onset"}
+    expected = {
+        "postal_code",
+        "address",
+        "phone",
+        "chief_complaint",
+        "symptom_location",
+        "onset",
+        "pregnancy",
+        "breastfeeding",
+    }
     assert expected.issubset(ids)
 
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -595,3 +595,11 @@
 - [x] 変更（バックエンド）: `backend/app/llm_gateway.py`, `backend/app/main.py`, `backend/tests/test_api.py`
 - [x] 変更（フロントエンド）: `frontend/src/pages/AdminTemplates.tsx`
 - [x] ドキュメント更新: `docs/LLMcommunication.md`, `docs/session_api.md`, `docs/implementation.md`
+
+## 75. デフォルトテンプレートの性別関連項目整理（2025-12-08）
+- [x] 初診デフォルトテンプレートから性別質問を削除し、重複入力を解消。
+- [x] 妊娠・授乳の質問に対象性別を設定し、女性のみ表示されるよう変更。
+- [x] 喫煙・飲酒の質問に自由記述欄を追加し、選択肢以外の回答を許容。
+- [x] 変更（バックエンド）: `backend/app/main.py`, `backend/build/lib/app/main.py`
+- [x] テスト更新: `backend/tests/test_api.py`
+- [x] ドキュメント更新: `docs/implementation.md`


### PR DESCRIPTION
## 概要
- 初診デフォルトテンプレートから性別質問を削除
- 妊娠・授乳の質問に対象性別を設定し女性のみ表示
- 喫煙・飲酒の質問で自由記述を許容

## テスト
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af9f4f8e00832f8c73a72fa690e035