### PR TITLE
単一選択入力の廃止と複数選択への統一

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 node_modules/
 venv
 backend/.venv/
+.venv/

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -398,7 +398,10 @@ def upsert_template(
 ) -> None:
     conn = get_conn(db_path)
     try:
-        items_json = json.dumps(list(items), ensure_ascii=False)
+        normalized_items = [
+            {**it, "type": "multi"} if it.get("type") == "single" else it for it in items
+        ]
+        items_json = json.dumps(list(normalized_items), ensure_ascii=False)
         conn.execute(
             """
             INSERT INTO questionnaire_templates (id, visit_type, items_json, llm_followup_enabled, llm_followup_max_questions)
@@ -429,12 +432,18 @@ def get_template(
         ).fetchone()
         if not row:
             return None
+        items = json.loads(row["items_json"]) or []
+        for it in items:
+            if it.get("type") == "single":
+                it["type"] = "multi"
         return {
             "id": row["id"],
             "visit_type": row["visit_type"],
-            "items": json.loads(row["items_json"]) or [],
+            "items": items,
             "llm_followup_enabled": bool(row.get("llm_followup_enabled", 1)),
-            "llm_followup_max_questions": int(row.get("llm_followup_max_questions", 5)),
+            "llm_followup_max_questions": int(
+                row.get("llm_followup_max_questions", 5)
+            ),
         }
     finally:
         conn.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -134,7 +134,7 @@ def on_startup() -> None:
         {
             "id": "onset",
             "label": "いつから症状がありますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,
@@ -262,7 +262,7 @@ def on_startup() -> None:
         {
             "id": "smoking",
             "label": "タバコは吸いますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
             "allow_freetext": True,
             "required": False,
@@ -270,7 +270,7 @@ def on_startup() -> None:
         {
             "id": "alcohol",
             "label": "お酒はのみますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["のまない", "ときどき", "よく飲む"],
             "allow_freetext": True,
             "required": False,
@@ -297,7 +297,7 @@ def on_startup() -> None:
         {
             "id": "onset",
             "label": "いつからの症状ですか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,
@@ -621,7 +621,7 @@ def reset_default_template() -> dict:
         {
             "id": "onset",
             "label": "いつから症状がありますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,
@@ -749,7 +749,7 @@ def reset_default_template() -> dict:
         {
             "id": "smoking",
             "label": "タバコは吸いますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
             "allow_freetext": True,
             "required": False,
@@ -757,7 +757,7 @@ def reset_default_template() -> dict:
         {
             "id": "alcohol",
             "label": "お酒はのみますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["のまない", "ときどき", "よく飲む"],
             "allow_freetext": True,
             "required": False,
@@ -784,7 +784,7 @@ def reset_default_template() -> dict:
         {
             "id": "onset",
             "label": "いつからの症状ですか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,

--- a/backend/app/validator.py
+++ b/backend/app/validator.py
@@ -42,11 +42,6 @@ class Validator:
                     datetime.fromisoformat(str(value))
                 except Exception as exc:  # noqa: BLE001
                     raise HTTPException(status_code=400, detail=f"{key} は日付(YYYY-MM-DD)で入力してください") from exc
-            elif item_type == "single":
-                if not isinstance(value, str):
-                    raise HTTPException(status_code=400, detail=f"{key} は単一選択です")
-                if options and value not in list(options):
-                    raise HTTPException(status_code=400, detail=f"{key} の値が不正です")
             elif item_type == "yesno":
                 if not isinstance(value, str):
                     raise HTTPException(status_code=400, detail=f"{key} は YES/NO を選択してください")

--- a/backend/build/lib/app/main.py
+++ b/backend/build/lib/app/main.py
@@ -129,7 +129,7 @@ def on_startup() -> None:
         {
             "id": "onset",
             "label": "いつから症状がありますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,
@@ -257,7 +257,7 @@ def on_startup() -> None:
         {
             "id": "smoking",
             "label": "タバコは吸いますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
             "allow_freetext": True,
             "required": False,
@@ -265,7 +265,7 @@ def on_startup() -> None:
         {
             "id": "alcohol",
             "label": "お酒はのみますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["のまない", "ときどき", "よく飲む"],
             "allow_freetext": True,
             "required": False,
@@ -292,7 +292,7 @@ def on_startup() -> None:
         {
             "id": "onset",
             "label": "いつからの症状ですか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,
@@ -603,7 +603,7 @@ def reset_default_template() -> dict:
         {
             "id": "onset",
             "label": "いつから症状がありますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,
@@ -731,7 +731,7 @@ def reset_default_template() -> dict:
         {
             "id": "smoking",
             "label": "タバコは吸いますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["吸わない", "時々吸う", "毎日吸う"],
             "allow_freetext": True,
             "required": False,
@@ -739,7 +739,7 @@ def reset_default_template() -> dict:
         {
             "id": "alcohol",
             "label": "お酒はのみますか？",
-            "type": "single",
+            "type": "multi",
             "options": ["のまない", "ときどき", "よく飲む"],
             "allow_freetext": True,
             "required": False,
@@ -766,7 +766,7 @@ def reset_default_template() -> dict:
         {
             "id": "onset",
             "label": "いつからの症状ですか？",
-            "type": "single",
+            "type": "multi",
             "options": ["昨日から", "1週間前から", "1ヶ月前から"],
             "allow_freetext": True,
             "required": True,

--- a/backend/build/lib/app/validator.py
+++ b/backend/build/lib/app/validator.py
@@ -42,11 +42,6 @@ class Validator:
                     datetime.fromisoformat(str(value))
                 except Exception as exc:  # noqa: BLE001
                     raise HTTPException(status_code=400, detail=f"{key} は日付(YYYY-MM-DD)で入力してください") from exc
-            elif item_type == "single":
-                if not isinstance(value, str):
-                    raise HTTPException(status_code=400, detail=f"{key} は単一選択です")
-                if options and value not in list(options):
-                    raise HTTPException(status_code=400, detail=f"{key} の値が不正です")
             elif item_type == "yesno":
                 if not isinstance(value, str):
                     raise HTTPException(status_code=400, detail=f"{key} は YES/NO を選択してください")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -339,7 +339,7 @@ def test_questionnaire_options() -> None:
             {
                 "id": "color",
                 "label": "色",
-                "type": "single",
+                "type": "multi",
                 "required": True,
                 "options": ["red", "blue"],
                 "description": "説明",
@@ -378,7 +378,7 @@ def test_questionnaire_when() -> None:
             {
                 "id": "symptom",
                 "label": "症状の有無",
-                "type": "single",
+                "type": "multi",
                 "required": True,
                 "options": ["あり", "なし"],
             },

--- a/docs/PlannedDesign.md
+++ b/docs/PlannedDesign.md
@@ -69,7 +69,7 @@
 
 ### 3.3 Questionnaire（/questionnaire）
 - **表示**：選択した種別に紐づくテンプレートの項目
-  - 入力型：単一選択、複数選択、数値、日付、テキスト（複数行）
+  - 入力型：複数選択、数値、日付、テキスト（複数行）
   - 任意の軽い条件分岐は即時反映（例：施術希望=あり → 施術関連項目を表示）
 - **アクション**：
   - 一時保存（ローカル：sessionStorage）
@@ -107,7 +107,7 @@
 - **タブ**：初診 / 再診
 - **項目リスト**：
   - 各項目：`項目ID`、`表示名`、`入力型`、`必須`、`説明文`、`条件表示（任意）`
-  - 入力型：単一選択 / 複数選択 / 数値 / 日付 / テキスト
+  - 入力型：複数選択 / 数値 / 日付 / テキスト
   - 選択肢（入力型が選択のとき）
 - **操作**：項目の追加/並替/削除、プレビュー（右パネル）
 - **検証**：重複IDの禁止、必須項目の不足チェック
@@ -271,7 +271,7 @@ interface QuestionItem {
   inputType: 'text' | 'multi' | 'yesno' | 'date';
   required?: boolean;
   description?: string;
-  options?: { value: string; label: string }[]; // single/multi
+  options?: { value: string; label: string }[]; // multi
   allowFreeText?: boolean; // multi のときに自由記述欄をチェックボックスで有効化
   when?: { itemId: string; operator: 'eq' | 'ne' | 'in' | 'nin'; value: any }[];
   gender?: 'male' | 'female' | 'both'; // 省略または 'both' で男女共通

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -614,3 +614,10 @@
 ## 76. ラッパーGUI録音エラーの修正（2025-12-09）
 - [x] 例外変数がガーベジコレクトされてしまいエラーメッセージが表示できなかった不具合を修正。
 - [x] 変更: `wrapper/app/gui.py`
+
+## 77. 単一選択入力の廃止（2025-12-10）
+- [x] 単一選択入力方式を廃止し、既存の単一選択項目を複数選択に統一。
+- [x] 変更（バックエンド）: `backend/app/main.py`, `backend/app/db.py`, `backend/app/validator.py`
+- [x] 変更（フロントエンド）: `frontend/src/pages/AdminTemplates.tsx`, `frontend/src/pages/QuestionnaireForm.tsx`
+- [x] テスト更新: `backend/tests/test_api.py`
+- [x] ドキュメント更新: `docs/PlannedDesign.md`, `docs/implementation.md`

--- a/frontend/src/pages/AdminTemplates.tsx
+++ b/frontend/src/pages/AdminTemplates.tsx
@@ -346,8 +346,8 @@ export default function AdminTemplates() {
   const changeItemType = (index: number, newType: string) => {
     const target = items[index];
     const next: Item = { ...target, type: newType } as Item;
-    if (newType === 'multi' || newType === 'single') {
-      // 複数/単一選択に切り替えた場合、自由記述をデフォルトON、選択肢を最低限用意
+    if (newType === 'multi') {
+      // 複数選択に切り替えた場合、自由記述をデフォルトON、選択肢を最低限用意
       next.allow_freetext = true;
       next.options = (target.options && target.options.length > 0) ? target.options : ['', 'その他'];
     } else {
@@ -503,7 +503,7 @@ export default function AdminTemplates() {
     setTemplates([...templates, { id: newId }]);
     setTemplateId(newId);
     // 新規テンプレート作成時のデフォルト問診項目は「質問文形式」をベースに、
-    // 発症時期は単一選択＋自由記述をあらかじめ用意する
+    // 発症時期は複数選択＋自由記述をあらかじめ用意する
     setItems([
       {
         id: crypto.randomUUID(),
@@ -516,7 +516,7 @@ export default function AdminTemplates() {
       {
         id: crypto.randomUUID(),
         label: '発症時期はいつからですか？',
-        type: 'single',
+        type: 'multi',
         required: false,
         options: ['昨日から', '1週間前から', '1ヶ月前から'],
         allow_freetext: true,
@@ -955,7 +955,6 @@ export default function AdminTemplates() {
                                         <FormLabel m={0}>入力方法</FormLabel>
                                         <Select value={item.type} onChange={(e) => changeItemType(idx, e.target.value)}>
                                           <option value="string">テキスト</option>
-                                          <option value="single">単一選択</option>
                                           <option value="multi">複数選択</option>
                                           <option value="yesno">はい/いいえ</option>
                                           <option value="date">日付</option>
@@ -970,7 +969,7 @@ export default function AdminTemplates() {
                                         onClick={() => removeItem(idx)}
                                       />
                                     </HStack>
-                                    {['multi', 'single'].includes(item.type) && (
+                                    {item.type === 'multi' && (
                                       <Box>
                                         <FormLabel m={0} mb={2}>選択肢</FormLabel>
                                         <VStack align="stretch">
@@ -1068,7 +1067,7 @@ export default function AdminTemplates() {
                     value={newItem.type}
                     onChange={(e) => {
                       const t = e.target.value;
-                      if (t === 'multi' || t === 'single') {
+                      if (t === 'multi') {
                         setNewItem({
                           ...newItem,
                           type: t,
@@ -1081,7 +1080,6 @@ export default function AdminTemplates() {
                     }}
                   >
                     <option value="string">テキスト</option>
-                    <option value="single">単一選択</option>
                     <option value="multi">複数選択</option>
                     <option value="yesno">はい/いいえ</option>
                     <option value="date">日付</option>

--- a/frontend/src/pages/QuestionnaireForm.tsx
+++ b/frontend/src/pages/QuestionnaireForm.tsx
@@ -212,20 +212,6 @@ export default function QuestionnaireForm() {
                     <Radio value="no" size="lg">いいえ</Radio>
                   </VStack>
                 </RadioGroup>
-              ) : item.type === 'single' && item.options ? (
-                <RadioGroup
-                  value={answers[item.id] || ''}
-                  onChange={(val) => setAnswers({ ...answers, [item.id]: val })}
-                  aria-describedby={helperText ? `help-item-${item.id}` : undefined}
-                >
-                  <VStack align="start" spacing={3}>
-                    {item.options.map((opt) => (
-                      <Radio key={opt} value={opt} size="lg">
-                        {opt}
-                      </Radio>
-                    ))}
-                  </VStack>
-                </RadioGroup>
               ) : item.type === 'multi' && item.options ? (
                 <>
                   <CheckboxGroup


### PR DESCRIPTION
## 概要
- 単一選択型の問診項目を廃止し、複数選択に統一
- 既存テンプレートの単一選択項目を読み書き時に自動変換
- 管理画面および患者画面から単一選択の選択肢を除外

## テスト
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b124229a90832f864fcb998a4ad9cb