### PR TITLE
feat: Docker での起動環境を追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+venv
+**/__pycache__
+backend/app/app.sqlite3
+frontend/node_modules
+frontend/dist

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+# バックエンドAPIを提供するコンテナ
+FROM python:3.11-slim
+
+WORKDIR /app
+# ソースコードをコピー
+COPY backend /app
+# 依存を仮想環境にインストール
+RUN python -m venv /venv \
+    && . /venv/bin/activate \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -e .
+# PATH を仮想環境に設定
+ENV PATH="/venv/bin:$PATH"
+EXPOSE 8001
+# Uvicorn でアプリを起動
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    volumes:
+      - ./backend/app:/app/app
+    ports:
+      - "8001:8001"
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -1,0 +1,15 @@
+# Docker での起動手順
+
+## 前提
+- Docker および Docker Compose がインストールされていること
+
+## ビルドと起動
+```bash
+docker compose build
+docker compose up -d
+```
+- フロントエンド: http://localhost:5173
+- バックエンド: http://localhost:8001
+
+## データ永続化
+- SQLite データベースは `backend/app/app.sqlite3` に作成され、ホスト側にボリュームとして保持されます。

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -680,3 +680,10 @@
 - [x] 変更（フロントエンド）: `frontend/src/pages/AdminLlm.tsx` の初期ステートおよびロード時の既定（null時）を `enabled: false` に変更。
 - [x] バックエンドのデフォルトは既に `enabled: false`（`default_llm_settings`）のため整合。
 - [x] バックエンド自動テスト実行: `cd backend && .venv/Scripts/pytest -q`（36件成功）
+
+## 88. Docker による起動対応（2025-12-13）
+- [x] バックエンド用 `backend/Dockerfile` を追加。
+- [x] フロントエンド用 `frontend/Dockerfile` と `frontend/nginx.conf` を追加。
+- [x] `docker-compose.yml` で両コンテナを一括起動可能にした。
+- [x] ドキュメント追加: `docs/docker_setup.md`
+- [x] バックエンド自動テスト実行: `cd backend && pytest -q`（36件成功）

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+# フロントエンドをビルドして配信するコンテナ
+FROM node:18 AS build
+WORKDIR /app
+# 依存をインストール
+COPY frontend/package*.json ./
+RUN npm install
+# ソースをコピーしてビルド
+COPY frontend ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+# ビルド成果物を配置
+COPY --from=build /app/dist /usr/share/nginx/html
+# バックエンドへのリバースプロキシ設定
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri /index.html;
+    }
+    # API はバックエンドへリバースプロキシ
+    location /questionnaires {
+        proxy_pass http://backend:8001;
+    }
+    location /sessions {
+        proxy_pass http://backend:8001;
+    }
+    location /llm {
+        proxy_pass http://backend:8001;
+    }
+    location /healthz {
+        proxy_pass http://backend:8001;
+    }
+    location /readyz {
+        proxy_pass http://backend:8001;
+    }
+    location /metrics {
+        proxy_pass http://backend:8001;
+    }
+}


### PR DESCRIPTION
## 概要
- バックエンド・フロントエンドそれぞれの Dockerfile を追加
- nginx 設定と docker-compose により一括起動をサポート
- Docker 起動手順のドキュメントを追加

## テスト
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2b439ec18832fbce9ade1e102f3be