### PR TITLE
CouchDB の _users データベースを自動作成して認証エラーを解消

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -44,6 +44,14 @@ if COUCHDB_URL:
         _server = couchdb.Server(COUCHDB_URL)
         if COUCHDB_USER and COUCHDB_PASSWORD:
             _server.resource.credentials = (COUCHDB_USER, COUCHDB_PASSWORD)
+        # `_users` データベースが存在しないと認証キャッシュでエラーが出るため、
+        # 初回起動時に自動作成しておく。
+        try:  # pragma: no cover - 既存環境では作成済みの場合があるため
+            _server["_users"]
+        except couchdb.http.ResourceNotFound:  # pragma: no cover - 実行時のみ
+            _server.create("_users")
+        except Exception:
+            pass
         try:
             couch_db = _server[COUCHDB_DB_NAME]
         except couchdb.http.ResourceNotFound:

--- a/internal_docs/docker_setup.md
+++ b/internal_docs/docker_setup.md
@@ -12,6 +12,8 @@ docker compose up -d
 - バックエンド: http://localhost:8001
 - CouchDB 管理画面: http://localhost:5984/_utils
 - `docker-compose.yml` では CouchDB の認証情報を `COUCHDB_USER` と `COUCHDB_PASSWORD` で指定する。
+- `_users` データベースが存在しない場合、バックエンド起動時に自動作成されるため、
+  初回起動時の認証キャッシュエラーが解消される。
 
 ## データ永続化
 - セッションデータは CouchDB に保存され、`couchdb_data` ボリュームで永続化されます。

--- a/internal_docs/implementation.md
+++ b/internal_docs/implementation.md
@@ -771,3 +771,8 @@
 - [x] 変更（バックエンド）: `backend/app/main.py`
 - [x] ドキュメント更新: `docs/admin_user_manual.md`
 - [x] バックエンド自動テスト実行: `ADMIN_PASSWORD=admin .venv/bin/pytest -q`（37件成功）
+
+## 93. `_users` データベース自動作成（2025-12-15）
+- [x] CouchDB 起動時に `_users` が存在しない場合、バックエンドが自動作成するよう修正。
+- [x] ドキュメント更新: `internal_docs/docker_setup.md`
+- [x] バックエンド自動テスト実行: `cd backend && .venv/bin/pytest -q`


### PR DESCRIPTION
## 概要
- CouchDB 起動時に `_users` DB を自動作成し、`chttpd_auth_cache` のエラーを防止
- Docker 起動手順に `_users` DB 自動作成について追記
- 実装手順書を更新

## テスト
- `cd backend && ADMIN_PASSWORD=admin .venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75a402fe4832f882c92157b79e9a7