### PR TITLE
サンプル環境変数でCouchDBへ接続できるように設定

### DIFF
--- a/backend/.env copy.example
+++ b/backend/.env copy.example
@@ -14,9 +14,9 @@
 # CouchDB 接続設定
 # 有効な URL を指定するとセッションデータを CouchDB に保存します。
 # 認証情報は `COUCHDB_USER` / `COUCHDB_PASSWORD` で指定してください。
-#COUCHDB_URL=http://localhost:5984/
+COUCHDB_URL=http://couchdb:5984/
 # 使用するデータベース名（未指定時は 'monshin_sessions'）
-#COUCHDB_DB=monshin_sessions
-#COUCHDB_USER=admin
-#COUCHDB_PASSWORD=change-me
+COUCHDB_DB=monshin_sessions
+COUCHDB_USER=admin
+COUCHDB_PASSWORD=admin
 

--- a/docs/session_api.md
+++ b/docs/session_api.md
@@ -49,7 +49,7 @@
   - `finalized_at` (str): ISO8601形式の確定時刻
   - `status` (str): `finalized`
 
-※ セッションと回答は既定で CouchDB に保存される。固定項目の回答に加え、LLM による追加質問で提示された「質問文」とその回答のペアも保存対象。環境変数 `COUCHDB_URL` を設定しない場合は従来通り SQLite に保存される。`COUCHDB_URL` に認証情報を含めない場合は、`COUCHDB_USER` と `COUCHDB_PASSWORD` を併せて設定する。CouchDB が設定されているにもかかわらず保存に失敗した場合、SQLite へは保存されずエラーとなる。
+※ セッションと回答は既定で CouchDB に保存される。固定項目の回答に加え、LLM による追加質問で提示された「質問文」とその回答のペアも保存対象。環境変数 `COUCHDB_URL` を設定しない場合は従来通り SQLite に保存される。`COUCHDB_URL` に認証情報を含めない場合は、`COUCHDB_USER` と `COUCHDB_PASSWORD` を併せて設定する。CouchDB が設定されているにもかかわらず保存に失敗した場合、SQLite へは保存されずエラーとなる。サンプル `.env` では `COUCHDB_URL=http://couchdb:5984/` などが設定されており、Docker Compose で構築した CouchDB とそのまま連携できる。
 
 ## GET /llm/settings
 - 概要: 現在の LLM 設定を取得する。

--- a/internal_docs/docker_setup.md
+++ b/internal_docs/docker_setup.md
@@ -12,6 +12,7 @@ docker compose up -d
 - バックエンド: http://localhost:8001
 - CouchDB 管理画面: http://localhost:5984/_utils
 - `docker-compose.yml` では CouchDB の認証情報を `COUCHDB_USER` と `COUCHDB_PASSWORD` で指定する。
+- `backend/.env copy.example` には `COUCHDB_URL=http://couchdb:5984/` などの既定値が含まれており、そのままコピーすれば compose 内の CouchDB に接続できる。CouchDB を使わない場合はこれらの環境変数を削除する。
 - `_users` データベースが存在しない場合、バックエンド起動時に自動作成されるため、
   初回起動時の認証キャッシュエラーが解消される。
 

--- a/internal_docs/implementation.md
+++ b/internal_docs/implementation.md
@@ -800,3 +800,8 @@
 - [x] CouchDB へのセッション保存時に `_rev` を付与し、`ResourceConflict` 発生時は最新リビジョンを取得して再試行するよう修正。
   - 変更: `backend/app/db.py`
 - [x] バックエンド自動テスト実行: `cd backend && pytest -q`（39件成功）
+
+## 98. CouchDB用環境変数の既定値設定（2025-12-20）
+- [x] `backend/.env copy.example` の CouchDB 関連変数をデフォルト値に設定し、リポジトリ同梱の CouchDB に接続できるようにした。
+- [x] ドキュメント更新: `internal_docs/docker_setup.md`, `docs/session_api.md`。
+- [x] バックエンド自動テスト実行: `cd backend && pytest -q`。


### PR DESCRIPTION
## Summary
- `.env` サンプルに CouchDB の接続情報を既定値として記載
- ドキュメントに既定の CouchDB 接続設定を追記
- 実装手順書を更新

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e387262c832f8b055bef907d134c